### PR TITLE
Add an agenda item to discuss plans for FPWD of WebXR

### DIFF
--- a/meetings/wg/2018-11-14-Immersive_Web_Working_Group_Teleconference-agenda.md
+++ b/meetings/wg/2018-11-14-Immersive_Web_Working_Group_Teleconference-agenda.md
@@ -18,6 +18,7 @@ This agenda can be viewed and updated on [Github](https://github.com/immersive-w
 
 If you would like to add an item to the agenda or volunteer to scribe please open a pull request against this agenda.
 
+* Toward a First Public Working Draft for WebXR Device API: [FPWD-targeted issues](https://github.com/immersive-web/webxr/milestone/6) [Definition of First Public Working Draft in W3C Process](https://www.w3.org/2018/Process-20180201/#first-wd)
 * Show and tell: [description]
 * [Define how to request features which require user consent](https://github.com/immersive-web/webxr/issues/424) - toji - [description]
 * [Allow session creation to be blocked on required features](https://github.com/immersive-web/webxr/issues/423) - toji - [description]


### PR DESCRIPTION
Goal is to discuss a timeline and give a heads-up to the WG about our plans to bring the WebXR Device API to First Public Working Draft status in the next few weeks (as per our charter)